### PR TITLE
Add a bash hook to run most commands via scicmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 SciCommander
 ============
 
-![Run Python Tests](https://github.com/samuell/scicommander/actions/workflows/python-run-tests.yml/badge.svg)
+[![Run Python Tests](https://github.com/samuell/scicommander/actions/workflows/python-run-tests.yml/badge.svg)](https://github.com/samuell/scicommander/actions/workflows/python-run-tests.yml)
 
 This is a small tool that executes single shell commands in a scientifically
 more reproducible and robust way, by doing the following things:

--- a/python/scicommander/scicmd.py
+++ b/python/scicommander/scicmd.py
@@ -34,7 +34,10 @@ def main():
         return
 
     command = " ".join(args.command)
+    parse_and_execute(command)
 
+
+def parse_and_execute(command):
     # Capture input paths
     input_paths = []
     input_matches = get_input_matches(command)

--- a/python/scripts/scishell
+++ b/python/scripts/scishell
@@ -1,0 +1,10 @@
+#!/bin/bash
+function init_scishell() {
+    bash --rcfile <(cat << EOF
+        export PS1="\033[32mscish > \033[39m"
+        shopt -s extdebug
+        trap 'if [[ \$BASH_COMMAND == ls* || \$BASH_COMMAND == cd* || \$BASH_COMMAND == pwd* || \$BASH_COMMAND == compopt* || \$BASH_COMMAND == \[\[* ]]; then \$BASH_COMMAND; else scicmd -c \$BASH_COMMAND; fi; false' DEBUG
+EOF
+)
+}
+init_scishell

--- a/python/setup.py
+++ b/python/setup.py
@@ -41,4 +41,5 @@ setup(
             "scicmd=scicommander.scicmd:main",
         ],
     },
+    scripts=["scripts/scishell"]
 )


### PR DESCRIPTION
This change adds a bash script, `scishell`, which after started, will run most command (except some common ones like ls, pwd etc) via the `scicmd` command from SciCommander.